### PR TITLE
Added —with-names option to prepublish bash script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ I highly recommend using Roger Veciana’s [d3-composite-projections](https://gi
 ## Generating the files
 Clone or download the repo, start a terminal and run `npm install` in the folder. This command will run the script and move the generated files to the `es` folder.
 
-If you need to make further adjustments (simplification, quantization) you can change the `prepublish` script and run `npm install` again. 
+If you need to make further adjustments (simplification, quantization) you can change the `prepublish` script and run `npm install` again.
+A convenience option was added to the prepublish script in case you want to attach the corresponding feature name (extracted from NAMEUNIT in shp files) to the resulting JSON. In order to do so, run `bash prepublish --with-names` from your terminal.
 
 ## File Reference
 <a href="#es/municipalities.json" name="es/municipalities.json">#</a> <b>es/municipalities.json</b> [<>](https://martingonzalez.net/es-municipalities.v1.json "Source")

--- a/prepublish
+++ b/prepublish
@@ -12,7 +12,6 @@ if [ -n "$1" ]
     if [[ "$1" == "-n" || "$1" == "--with-names" ]]
       then
         NDJSON_ARGS="(d.name=d.properties.NAMEUNIT, delete d.properties, d)"
-        echo 'Working'
     fi
 fi
 

--- a/prepublish
+++ b/prepublish
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+#set path to installed node modules when this script is run without npm 
+PATH=$PATH:./node_modules/.bin
+
+#ndjson args
+NDJSON_ARGS="(delete d.properties, d)"
+
+
+if [ -n "$1" ] 
+  then 
+    if [[ "$1" == "-n" || "$1" == "--with-names" ]]
+      then
+        NDJSON_ARGS="(d.name=d.properties.NAMEUNIT, delete d.properties, d)"
+        echo 'Working'
+    fi
+fi
+
 # Simplification
 SP=0.0001
 
@@ -46,13 +62,13 @@ topo2geo -n \
 geo2topo -n \
   provinces=<( \
       cat es/_provinces.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   autonomous_regions=<( \
       cat es/_autonomous_regions.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   nation=<( \
       cat es/_nation.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   | topoquantize $QU \
   > es/provinces.json
 
@@ -68,16 +84,16 @@ topo2geo -n \
 geo2topo -n \
   municipalities=<( \
       cat es/_municipalities.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   provinces=<( \
       cat es/_provinces.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   autonomous_regions=<( \
       cat es/_autonomous_regions.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   nation=<( \
       cat es/_nation.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   | topoquantize $QU \
   > es/municipalities.json
 


### PR DESCRIPTION
Hello, I found that the resulting TopoJSON doesn't include provinces/municipalities names. While this might not always be necessary I think it was good to have the option in the prepublish script. 

This needs to be run with `bash prepublish --with-names` after successfully executing `npm install`. 

Hope you find it useful, feel free to suggest any modifications!