### PR TITLE
Added —with-names option to prepublish bash script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ I highly recommend using Roger Veciana’s [d3-composite-projections](https://gi
 Clone or download the repo, start a terminal and run `npm install` in the folder. This command will run the script and move the generated files to the `es` folder.
 
 If you need to make further adjustments (simplification, quantization) you can change the `prepublish` script and run `npm install` again. 
-A convenience option was added to the prepublish script in case you want to attach the corresponding feature name (extracted from NAMEUNIT in shp files) to the resulting JSON. In order to do so, run `bash prepublish --with-names` from your terminal.
+A convenience option was added to the prepublish script in case you want to keep the corresponding feature name (extracted from NAMEUNIT in shp files) to the resulting JSON (under `d.properties`). In order to do so, run `bash prepublish --with-names` from your terminal.
 
 ## File Reference
 <a href="#es/municipalities.json" name="es/municipalities.json">#</a> <b>es/municipalities.json</b> [<>](https://martingonzalez.net/es-municipalities.v1.json "Source")

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ I highly recommend using Roger Veciana’s [d3-composite-projections](https://gi
 Clone or download the repo, start a terminal and run `npm install` in the folder. This command will run the script and move the generated files to the `es` folder.
 
 If you need to make further adjustments (simplification, quantization) you can change the `prepublish` script and run `npm install` again. 
+A convenience option was added to the prepublish script in case you want to attach the corresponding feature name (extracted from NAMEUNIT in shp files) to the resulting JSON. In order to do so, run `bash prepublish --with-names` from your terminal.
 
 ## File Reference
 <a href="#es/municipalities.json" name="es/municipalities.json">#</a> <b>es/municipalities.json</b> [<>](https://martingonzalez.net/es-municipalities.v1.json "Source")

--- a/prepublish
+++ b/prepublish
@@ -24,7 +24,7 @@ QU=1e4
 rm -rvf es
 mkdir -p build es
 
-curl -o build/lineas_limite.zip -C - 'http://centrodedescargas.cnig.es/CentroDescargas/equipamiento/lineas_limite.zip'
+curl -o build/lineas_limite.zip -C - 'https://media.githubusercontent.com/media/martgnz/es-shp-zip/master/lineas_limite.zip'
 unzip -jod build build/lineas_limite.zip recintos_municipales* recintos_provinciales*
 
 geo2topo -n provinces=<( \

--- a/prepublish
+++ b/prepublish
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+#set path to installed node modules when this script is run without npm 
+PATH=$PATH:./node_modules/.bin
+
+#ndjson args
+NDJSON_ARGS="(delete d.properties, d)"
+
+
+if [ -n "$1" ] 
+  then 
+    if [[ "$1" == "-n" || "$1" == "--with-names" ]]
+      then
+        NDJSON_ARGS="(name = d.properties.NAMEUNIT, delete d.properties, d.properties={}, d.properties.name=name, d)"
+    fi
+fi
+
 # Simplification
 SP=0.0001
 
@@ -46,13 +61,13 @@ topo2geo -n \
 geo2topo -n \
   provinces=<( \
       cat es/_provinces.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   autonomous_regions=<( \
       cat es/_autonomous_regions.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   nation=<( \
       cat es/_nation.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   | topoquantize $QU \
   > es/provinces.json
 
@@ -68,16 +83,16 @@ topo2geo -n \
 geo2topo -n \
   municipalities=<( \
       cat es/_municipalities.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   provinces=<( \
       cat es/_provinces.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   autonomous_regions=<( \
       cat es/_autonomous_regions.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   nation=<( \
       cat es/_nation.json \
-        | ndjson-map '(delete d.properties, d)') \
+        | ndjson-map "$NDJSON_ARGS") \
   | topoquantize $QU \
   > es/municipalities.json
 

--- a/prepublish
+++ b/prepublish
@@ -3,15 +3,11 @@
 #set path to installed node modules when this script is run without npm 
 PATH=$PATH:./node_modules/.bin
 
-#ndjson args
-NDJSON_ARGS="(delete d.properties, d)"
 
-
-if [ -n "$1" ] 
-  then 
-    if [[ "$1" == "-n" || "$1" == "--with-names" ]]
-      then
-        NDJSON_ARGS="(name = d.properties.NAMEUNIT, delete d.properties, d.properties={}, d.properties.name=name, d)"
+NDJSONMAP_ARGS="(delete d.properties, d)"
+if [ -n "${WITH_NAMES+set}" ]; then
+    if [ $WITH_NAMES = true ]; then
+        NDJSONMAP_ARGS="(name = d.properties.NAMEUNIT, delete d.properties, d.properties={}, d.properties.name=name, d)"
     fi
 fi
 
@@ -25,7 +21,17 @@ rm -rvf es
 mkdir -p build es
 
 curl -o build/lineas_limite.zip -C - 'https://media.githubusercontent.com/media/martgnz/es-shp-zip/master/lineas_limite.zip'
-unzip -jod build build/lineas_limite.zip recintos_municipales* recintos_provinciales*
+unzip -jod build build/lineas_limite.zip recintos_municipales* recintos_provinciales* recintos_autonomicas*
+
+geo2topo -n autonomous_regions=<( \
+    shp2json --encoding utf8 -n build/recintos_autonomicas_inspire_peninbal_etrs89.shp \
+      | ndjson-map '(d.id = d.properties.NATCODE.slice(2, 4), d)'
+    shp2json --encoding utf8 -n build/recintos_autonomicas_inspire_canarias_wgs84.shp \
+      | ndjson-map '(d.id = d.properties.NATCODE.slice(2, 4), d)') \
+  | toposimplify -f -p $SP \
+  | topomerge nation=autonomous_regions \
+  > es/autonomous_regions.json
+
 
 geo2topo -n provinces=<( \
     shp2json --encoding utf8 -n build/recintos_provinciales_inspire_peninbal_etrs89.shp \
@@ -52,22 +58,36 @@ geo2topo -n municipalities=<( \
 # Re-compute the topology as a further optimization.
 # This consolidates unique sequences of arcs.
 # https://github.com/topojson/topojson-simplify/issues/4
+
 topo2geo -n \
-  < es/provinces.json \
-  provinces=es/_provinces.json \
+  < es/autonomous_regions.json \
   autonomous_regions=es/_autonomous_regions.json \
   nation=es/_nation.json
 
 geo2topo -n \
-  provinces=<( \
-      cat es/_provinces.json \
-        | ndjson-map "$NDJSON_ARGS") \
   autonomous_regions=<( \
       cat es/_autonomous_regions.json \
-        | ndjson-map "$NDJSON_ARGS") \
+        | ndjson-map "$NDJSONMAP_ARGS") \
   nation=<( \
       cat es/_nation.json \
-        | ndjson-map "$NDJSON_ARGS") \
+        | ndjson-map "$NDJSONMAP_ARGS") \
+  | topoquantize $QU \
+  > es/autonomous_regions.json
+
+topo2geo -n \
+  < es/provinces.json \
+  provinces=es/_provinces.json
+
+geo2topo -n \
+  provinces=<( \
+      cat es/_provinces.json \
+        | ndjson-map "$NDJSONMAP_ARGS") \
+  autonomous_regions=<( \
+      cat es/_autonomous_regions.json \
+        | ndjson-map "$NDJSONMAP_ARGS") \
+  nation=<( \
+      cat es/_nation.json \
+        | ndjson-map "$NDJSONMAP_ARGS") \
   | topoquantize $QU \
   > es/provinces.json
 
@@ -83,16 +103,16 @@ topo2geo -n \
 geo2topo -n \
   municipalities=<( \
       cat es/_municipalities.json \
-        | ndjson-map "$NDJSON_ARGS") \
+        | ndjson-map "$NDJSONMAP_ARGS") \
   provinces=<( \
       cat es/_provinces.json \
-        | ndjson-map "$NDJSON_ARGS") \
+        | ndjson-map "$NDJSONMAP_ARGS") \
   autonomous_regions=<( \
       cat es/_autonomous_regions.json \
-        | ndjson-map "$NDJSON_ARGS") \
+        | ndjson-map "$NDJSONMAP_ARGS") \
   nation=<( \
       cat es/_nation.json \
-        | ndjson-map "$NDJSON_ARGS") \
+        | ndjson-map "$NDJSONMAP_ARGS") \
   | topoquantize $QU \
   > es/municipalities.json
 


### PR DESCRIPTION
Hello again. Sorry for the hassle 😅
I'm quite a newbie to TopoJSON and didn't know that items not listed under the properties object are removed when parsed into GeoJSON features...that's why I closed the other PR. 

Anyhow, I find it useful to include feature's names in the resulting geojson, as I personally use it a lot in my projects, and thought others could benefit from it as well. (now the feature name is kept under the properties object). 