### PR TITLE
Add filtering option by autonomous_regions id's option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ Removes points to reduce the file size. Set to `1e-4` by default.
 
 Removes information by reducing the precision of each coordinate. Set to `1e4` by default.
 
-<a href="#autonomous_regions" name="autonomous_regions">#</a> <i>autonomous_regions</i>
+<a href="#autonomous-regions" name="autonomous-regions">#</a> <i>autonomous-regions</i>
 
 Filters the result by the given `id` of [autonomous regions](http://www.ine.es/en/daco/daco42/codmun/cod_ccaa_en.htm) separated by comma.
 
 ```shell
-npm run prepare --es-atlas:autonomous_regions=09,10,14,04
+npm run prepare --es-atlas:autonomous-regions=09,10,14,04
 ```
 
 ## File Reference

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ d3.json("https://unpkg.com/es-atlas@0.1.1/es/municipalities.json", function(erro
   context.beginPath();
   path(topojson.mesh(es));
   context.stroke();
-  
+
   context.stroke(new Path2D(projection.getCompositionBorders()));
 });
 
@@ -79,10 +79,18 @@ Removes points to reduce the file size. Set to `1e-4` by default.
 
 Removes information by reducing the precision of each coordinate. Set to `1e4` by default.
 
+<a href="#autonomous_regions" name="autonomous_regions">#</a> <i>autonomous_regions</i>
+
+Filters the result by the given `id` of [autonomous regions](http://www.ine.es/en/daco/daco42/codmun/cod_ccaa_en.htm) separated by comma.
+
+```shell
+npm run prepare --es-atlas:autonomous_regions=09,10,14,04
+```
+
 ## File Reference
 <a href="#es/municipalities.json" name="es/municipalities.json">#</a> <b>es/municipalities.json</b> [<>](https://unpkg.com/es-atlas/es/municipalities.json "Source")
 
-A TopoJSON which contains four objects: *municipalities*, *provinces*, *autonomous regions* and *nation*. Every city, province and region has its corresponding [National Statistics Institute](http://www.ine.es/en/welcome.shtml) identifier, so it's easy to get started. 
+A TopoJSON which contains four objects: *municipalities*, *provinces*, *autonomous regions* and *nation*. Every city, province and region has its corresponding [National Statistics Institute](http://www.ine.es/en/welcome.shtml) identifier, so it's easy to get started.
 
 <a href="#es/municipalities.json_municipalities" name="es/municipalities.json_municipalities">#</a> *es*.objects.<b>municipalities</b>
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ npm run prepare --es-atlas:autonomous-regions=09,10,14,04
 ## File Reference
 <a href="#es/municipalities.json" name="es/municipalities.json">#</a> <b>es/municipalities.json</b> [<>](https://unpkg.com/es-atlas/es/municipalities.json "Source")
 
-A TopoJSON which contains four objects: *municipalities*, *provinces*, *autonomous regions* and *nation*. Every city, province and region has its corresponding [National Statistics Institute](http://www.ine.es/en/welcome.shtml) identifier, so it's easy to get started.
+A TopoJSON which contains four objects: *municipalities*, *provinces*, *autonomous regions* and *border*. Every city, province and region has its corresponding [National Statistics Institute](http://www.ine.es/en/welcome.shtml) identifier, so it's easy to get started.
 
 <a href="#es/municipalities.json_municipalities" name="es/municipalities.json_municipalities">#</a> *es*.objects.<b>municipalities</b>
 
@@ -104,7 +104,7 @@ A TopoJSON which contains four objects: *municipalities*, *provinces*, *autonomo
 
 <img src="https://cloud.githubusercontent.com/assets/1236790/20868858/72ad886c-ba66-11e6-95eb-e995fa640fc7.png" width="480" height="auto">
 
-<a href="#es/municipalities.json_nation" name="es/municipalities.json_nation">#</a> *es*.objects.<b>nation</b>
+<a href="#es/municipalities.json_border" name="es/municipalities.json_border">#</a> *es*.objects.<b>border</b>
 
 <img src="https://cloud.githubusercontent.com/assets/1236790/20868860/871ab75c-ba66-11e6-8517-a7d6e2d5eac8.png" width="480" height="auto">
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,180 @@
+{
+  "name": "es-atlas",
+  "version": "0.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "acorn": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.3.tgz",
+      "integrity": "sha1-Gj6FC0KOc7prCdHMUn9aqtTQPvE=",
+      "dev": true
+    },
+    "array-source": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/array-source/-/array-source-0.0.4.tgz",
+      "integrity": "sha512-frNdc+zBn80vipY+GdcJkLEbMWj3xmzArYApmUGxoiV8uAu/ygcs9icPdsGdA26h0MkHUMW6EN2piIvVx+M5Mw==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+      "dev": true
+    },
+    "d3-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
+      "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw==",
+      "dev": true
+    },
+    "d3-dsv": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.3.tgz",
+      "integrity": "sha1-BJ/kPA9fYMf/fTdmFrx21vydN48=",
+      "dev": true,
+      "requires": {
+        "commander": "2.13.0",
+        "iconv-lite": "0.4.15",
+        "rw": "1.3.3"
+      }
+    },
+    "d3-geo": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
+      "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
+      "dev": true,
+      "requires": {
+        "d3-array": "1.2.1"
+      }
+    },
+    "d3-geo-projection": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.3.2.tgz",
+      "integrity": "sha512-fbIDeSs1n0Y3IxqjtljeHUong4YEK2YS7jR/YKQCoWYBRJLEcieSq1lciCB9+HuNIdJtD7xVRyXFiZGIqu3ydA==",
+      "dev": true,
+      "requires": {
+        "commander": "2.13.0",
+        "d3-array": "1.2.1",
+        "d3-geo": "1.9.1"
+      }
+    },
+    "file-source": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-source/-/file-source-0.6.1.tgz",
+      "integrity": "sha1-rhidSZN2a4Zad/g63Pm5pQTNN9w=",
+      "dev": true,
+      "requires": {
+        "stream-source": "0.3.5"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+      "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
+      "dev": true
+    },
+    "ndjson-cli": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ndjson-cli/-/ndjson-cli-0.3.0.tgz",
+      "integrity": "sha1-l6hUg8R/qYadKC5N+awKfR22V9k=",
+      "dev": true,
+      "requires": {
+        "acorn": "4.0.3",
+        "commander": "2.13.0",
+        "resolve": "1.5.0"
+      }
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "path-source": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/path-source/-/path-source-0.1.3.tgz",
+      "integrity": "sha512-dWRHm5mIw5kw0cs3QZLNmpUWty48f5+5v9nWD2dw3Y0Hf+s01Ag8iJEWV0Sm0kocE8kK27DrIowha03e1YR+Qw==",
+      "dev": true,
+      "requires": {
+        "array-source": "0.0.4",
+        "file-source": "0.6.1"
+      }
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=",
+      "dev": true
+    },
+    "shapefile": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/shapefile/-/shapefile-0.6.6.tgz",
+      "integrity": "sha512-rLGSWeK2ufzCVx05wYd+xrWnOOdSV7xNUW5/XFgx3Bc02hBkpMlrd2F1dDII7/jhWzv0MSyBFh5uJIy9hLdfuw==",
+      "dev": true,
+      "requires": {
+        "array-source": "0.0.4",
+        "commander": "2.13.0",
+        "path-source": "0.1.3",
+        "slice-source": "0.4.1",
+        "stream-source": "0.3.5",
+        "text-encoding": "0.6.4"
+      }
+    },
+    "slice-source": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/slice-source/-/slice-source-0.4.1.tgz",
+      "integrity": "sha1-QKV6wDxmaLXaIA4FN44AC/KmHXk=",
+      "dev": true
+    },
+    "stream-source": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/stream-source/-/stream-source-0.3.5.tgz",
+      "integrity": "sha512-ZuEDP9sgjiAwUVoDModftG0JtYiLUV8K4ljYD1VyUMRWtbVf92474o4kuuul43iZ8t/hRuiDAx1dIJSvirrK/g==",
+      "dev": true
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
+    "topojson-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.0.tgz",
+      "integrity": "sha1-H5kpOnfvQqRI0DKoGqmCtz82DS8=",
+      "dev": true,
+      "requires": {
+        "commander": "2.13.0"
+      }
+    },
+    "topojson-server": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.0.tgz",
+      "integrity": "sha1-N4546Hw5cqe1vixdYENptrrmnF4=",
+      "dev": true,
+      "requires": {
+        "commander": "2.13.0"
+      }
+    },
+    "topojson-simplify": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/topojson-simplify/-/topojson-simplify-3.0.2.tgz",
+      "integrity": "sha512-gyYSVRt4jO/0RJXKZQPzTDQRWV+D/nOfiljNUv0HBXslFLtq3yxRHrl7jbrjdbda5Ytdr7M8BZUI4OxU7tnbRQ==",
+      "dev": true,
+      "requires": {
+        "commander": "2.13.0",
+        "topojson-client": "3.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "0.1.1",
   "description": "Pre-built TopoJSON from the Spanish National Geographic Institute",
   "scripts": {
-    "prepare": "bash prepublish $npm_package_config_with_names $npm_package_config_simplification $npm_package_config_quantization",
+    "prepare": "bash prepublish $npm_package_config_with_names $npm_package_config_simplification $npm_package_config_quantization $npm_package_config_autonomous_regions",
     "postpublish": "git push && git push --tags && cd ../martgnz.github.io && git pull && cp -v ../es-atlas/es/provinces.json es-provinces.v1.json && cp -v ../es-atlas/es/municipalities.json es-municipalities.v1.json && cp -v ../es-atlas/es/autonomous_regions.json es-autonomous-regions.v1.json && git add es-autonomous-regions.v1.json es-provinces.v1.json es-municipalities.v1.json && git commit -m \"es-atlas ${npm_package_version}\" && git push && cd -"
   },
   "config": {
     "with-names": false,
     "simplification": 0.0001,
-    "quantization": 10000
+    "quantization": 10000,
+    "autonomous_regions": "all"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "with-names": false,
     "simplification": 0.0001,
     "quantization": 10000,
-    "autonomous_regions": "all"
+    "autonomous-regions": "all"
   },
   "repository": {
     "type": "git",

--- a/prepublish
+++ b/prepublish
@@ -1,16 +1,28 @@
 #!/bin/bash
 
-# Set path to installed node modules to run the script without npm 
+# Set path to installed node modules to run the script without npm
 PATH=$PATH:./node_modules/.bin
 
 # Default variables
 NDJSONMAP_ARGS="(delete d.properties, d)"
+NDJSONFILTER_ARGS='d'
 SP=$2
 QU=$3
+AUTONOMOUS_REGIONS_IDS=$4
 
 if [ "$1" = true ]; then
   echo "Adding names to the files"
   NDJSONMAP_ARGS="(name = d.properties.NAMEUNIT, delete d.properties, d.properties={}, d.properties.name=name, d)"
+fi
+
+if [ "$4" != all ]; then
+  CCAA=()
+  IFS=',' read -r -a array <<< $AUTONOMOUS_REGIONS_IDS
+  for id in "${array[@]}";
+  do
+    CCAA+="\"$id\"",
+  done
+  NDJSONFILTER_ARGS="[${CCAA::-1}].includes(d.properties.NATCODE.slice(2, 4))"
 fi
 
 echo "Simplification: $SP"
@@ -24,32 +36,38 @@ unzip -jod build build/lineas_limite.zip recintos_municipales* recintos_provinci
 
 geo2topo -n autonomous_regions=<( \
     shp2json --encoding utf8 -n build/recintos_autonomicas_inspire_peninbal_etrs89.shp \
+      | ndjson-filter "$NDJSONFILTER_ARGS" \
       | ndjson-map '(d.id = d.properties.NATCODE.slice(2, 4), d)'
     shp2json --encoding utf8 -n build/recintos_autonomicas_inspire_canarias_wgs84.shp \
+      | ndjson-filter "$NDJSONFILTER_ARGS" \
       | ndjson-map '(d.id = d.properties.NATCODE.slice(2, 4), d)') \
   | toposimplify -f -p $SP \
-  | topomerge nation=autonomous_regions \
+  | topomerge border=autonomous_regions \
   > es/autonomous_regions.json
 
 geo2topo -n provinces=<( \
     shp2json --encoding utf8 -n build/recintos_provinciales_inspire_peninbal_etrs89.shp \
+      | ndjson-filter "$NDJSONFILTER_ARGS" \
       | ndjson-map '(d.id = d.properties.NATCODE.slice(4, 6), d)'
     shp2json --encoding utf8 -n build/recintos_provinciales_inspire_canarias_wgs84.shp \
+      | ndjson-filter "$NDJSONFILTER_ARGS" \
       | ndjson-map '(d.id = d.properties.NATCODE.slice(4, 6), d)') \
   | toposimplify -f -p $SP \
   | topomerge autonomous_regions=provinces -k 'd.properties.NATCODE.slice(2, 4)' \
-  | topomerge nation=autonomous_regions \
+  | topomerge border=autonomous_regions \
   > es/provinces.json
 
 geo2topo -n municipalities=<( \
     shp2json --encoding utf8 -n build/recintos_municipales_inspire_peninbal_etrs89.shp \
+      | ndjson-filter "$NDJSONFILTER_ARGS" \
       | ndjson-map '(d.id = d.properties.NATCODE.slice(6, 11), d)'
     shp2json --encoding utf8 -n build/recintos_municipales_inspire_canarias_wgs84.shp \
+      | ndjson-filter "$NDJSONFILTER_ARGS" \
       | ndjson-map '(d.id = d.properties.NATCODE.slice(6, 11), d)') \
   | toposimplify -f -p $SP \
   | topomerge provinces=municipalities -k 'd.properties.NATCODE.slice(4, 6)' \
   | topomerge autonomous_regions=municipalities -k 'd.properties.NATCODE.slice(2, 4)' \
-  | topomerge nation=autonomous_regions \
+  | topomerge border=autonomous_regions \
   > es/municipalities.json
 
 # Inspired by: https://bl.ocks.org/mbostock/39b34968ad5eab65de1d7da81f78bb27
@@ -60,14 +78,14 @@ geo2topo -n municipalities=<( \
 topo2geo -n \
   < es/autonomous_regions.json \
   autonomous_regions=es/_autonomous_regions.json \
-  nation=es/_nation.json
+  border=es/_border.json
 
 geo2topo -n \
   autonomous_regions=<( \
       cat es/_autonomous_regions.json \
         | ndjson-map "$NDJSONMAP_ARGS") \
-  nation=<( \
-      cat es/_nation.json \
+  border=<( \
+      cat es/_border.json \
         | ndjson-map "$NDJSONMAP_ARGS") \
   | topoquantize $QU \
   > es/autonomous_regions.json
@@ -83,21 +101,21 @@ geo2topo -n \
   autonomous_regions=<( \
       cat es/_autonomous_regions.json \
         | ndjson-map "$NDJSONMAP_ARGS") \
-  nation=<( \
-      cat es/_nation.json \
+  border=<( \
+      cat es/_border.json \
         | ndjson-map "$NDJSONMAP_ARGS") \
   | topoquantize $QU \
   > es/provinces.json
 
-rm es/_provinces.json es/_autonomous_regions.json es/_nation.json
+rm es/_provinces.json es/_autonomous_regions.json es/_border.json
 
 topo2geo -n \
   < es/municipalities.json \
   municipalities=es/_municipalities.json \
   provinces=es/_provinces.json \
   autonomous_regions=es/_autonomous_regions.json \
-  nation=es/_nation.json
-  
+  border=es/_border.json
+
 geo2topo -n \
   municipalities=<( \
       cat es/_municipalities.json \
@@ -108,10 +126,10 @@ geo2topo -n \
   autonomous_regions=<( \
       cat es/_autonomous_regions.json \
         | ndjson-map "$NDJSONMAP_ARGS") \
-  nation=<( \
-      cat es/_nation.json \
+  border=<( \
+      cat es/_border.json \
         | ndjson-map "$NDJSONMAP_ARGS") \
   | topoquantize $QU \
   > es/municipalities.json
 
-rm es/_municipalities.json es/_provinces.json es/_autonomous_regions.json es/_nation.json
+rm es/_municipalities.json es/_provinces.json es/_autonomous_regions.json es/_border.json

--- a/prepublish
+++ b/prepublish
@@ -20,11 +20,20 @@ if [ "$4" != all ]; then
   IFS=',' read -r -a array <<< $AUTONOMOUS_REGIONS_IDS
   for id in "${array[@]}";
   do
-    CCAA+="\"$id\"",
+    CCAA+="\"$id\""
   done
-  NDJSONFILTER_ARGS="[${CCAA::-1}].includes(d.properties.NATCODE.slice(2, 4))"
+  NDJSONFILTER_ARGS="${CCAA}.split(' ').includes(d.properties.NATCODE.slice(2, 4))"
+
+  # Change default quantization and simplification to have a sharper map
+  if [ "$2" = 0.0001 ]; then
+    SP=1e-5
+  fi
+  if [ "$3" = 10000 ]; then
+    QU=1e5
+  fi
 fi
 
+echo "Autonomous regions: $AUTONOMOUS_REGIONS_IDS"
 echo "Simplification: $SP"
 echo "Quantization: $QU"
 

--- a/prepublish
+++ b/prepublish
@@ -16,13 +16,7 @@ if [ "$1" = true ]; then
 fi
 
 if [ "$4" != all ]; then
-  CCAA=()
-  IFS=',' read -r -a array <<< $AUTONOMOUS_REGIONS_IDS
-  for id in "${array[@]}";
-  do
-    CCAA+="\"$id\""
-  done
-  NDJSONFILTER_ARGS="${CCAA}.split(' ').includes(d.properties.NATCODE.slice(2, 4))"
+  NDJSONFILTER_ARGS="'${AUTONOMOUS_REGIONS_IDS}'.split(',').includes(d.properties.NATCODE.slice(2, 4))"
 
   # Change default quantization and simplification to have a sharper map
   if [ "$2" = 0.0001 ]; then


### PR DESCRIPTION
This PR adds the possibility of filter the output topology using `autonomous_regions` `id's`.
Now you can run the script with `id's` as inline arguments separated by commas:

```shell
npm run prepare --es-atlas:autonomous_regions=09,10,14,04
```
Will generate the following result:
![preview](https://user-images.githubusercontent.com/11034169/35334542-156238ca-0113-11e8-849d-28f2a3121662.png)

This PR also changes the name of `nation` object to `border` as now it creates the contour of the nation or the selected autonomous regions.

Thanks @martgnz and @ale0xb for the last updates! :fire: