### PR TITLE
Add names on every administrative level

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,6 @@ npm run prepare --es-atlas:simplification=1e3
 
 ### Reference
 
-<a href="#add_names" name="add_names">#</a> <i>add_names</i>
-
-Adds a `name` property to the generated files with the feature name. Set to `true` by default.
-
 <a href="#simplification" name="simplification">#</a> <i>simplification</i>
 
 Removes points to reduce the file size. Set to `1e-4` by default.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "postpublish": "git push && git push --tags"
   },
   "config": {
-    "add_names": true,
     "simplification": 0.0001,
     "quantization": 10000,
     "autonomous_regions": "all"

--- a/prepublish
+++ b/prepublish
@@ -10,11 +10,6 @@ SIMPLIFICATION=$npm_package_config_simplification
 QUANTIZATION=$npm_package_config_quantization
 AUTONOMOUS_REGIONS_IDS=$npm_package_config_autonomous_regions
 
-if [ "$npm_package_config_add_names" = true ]; then
-  echo "Adding names to the files"
-  NDJSONMAP_ARGS="(name = d.properties.NAMEUNIT, delete d.properties, d.properties={}, d.properties.name=name, d)"
-fi
-
 if [ $AUTONOMOUS_REGIONS_IDS != all ]; then
   NDJSONFILTER_ARGS="'${AUTONOMOUS_REGIONS_IDS}'.split(',').includes(d.properties.NATCODE.slice(2, 4))"
 
@@ -51,6 +46,7 @@ geo2topo -n autonomous_regions=<( \
       | ndjson-filter "$NDJSONFILTER_ARGS" \
       | ndjson-map '(d.id = d.properties.NATCODE.slice(2, 4), d)') \
   | toposimplify -f -p $SIMPLIFICATION \
+  | topoquantize $QUANTIZATION \
   | topomerge border=autonomous_regions \
   > es/autonomous_regions.json
 
@@ -62,8 +58,10 @@ geo2topo -n provinces=<( \
       | ndjson-filter "$NDJSONFILTER_ARGS" \
       | ndjson-map '(d.id = d.properties.NATCODE.slice(4, 6), d)') \
   | toposimplify -f -p $SIMPLIFICATION \
+  | topoquantize $QUANTIZATION \
   | topomerge autonomous_regions=provinces -k 'd.properties.NATCODE.slice(2, 4)' \
   | topomerge border=autonomous_regions \
+  | node ./properties.js \
   > es/provinces.json
 
 geo2topo -n municipalities=<( \
@@ -74,71 +72,9 @@ geo2topo -n municipalities=<( \
       | ndjson-filter "$NDJSONFILTER_ARGS" \
       | ndjson-map '(d.id = d.properties.NATCODE.slice(6, 11), d)') \
   | toposimplify -f -p $SIMPLIFICATION \
+  | topoquantize $QUANTIZATION \
   | topomerge provinces=municipalities -k 'd.properties.NATCODE.slice(4, 6)' \
   | topomerge autonomous_regions=municipalities -k 'd.properties.NATCODE.slice(2, 4)' \
   | topomerge border=autonomous_regions \
+  | node ./properties.js \
   > es/municipalities.json
-
-# Inspired by: https://bl.ocks.org/mbostock/39b34968ad5eab65de1d7da81f78bb27
-# Re-compute the topology as a further optimization.
-# This consolidates unique sequences of arcs.
-# https://github.com/topojson/topojson-simplify/issues/4
-
-topo2geo -n \
-  < es/autonomous_regions.json \
-  autonomous_regions=es/_autonomous_regions.json \
-  border=es/_border.json
-
-geo2topo -n \
-  autonomous_regions=<( \
-      cat es/_autonomous_regions.json \
-        | ndjson-map "$NDJSONMAP_ARGS") \
-  border=<( \
-      cat es/_border.json \
-        | ndjson-map "$NDJSONMAP_ARGS") \
-  | topoquantize $QUANTIZATION \
-  > es/autonomous_regions.json
-
-topo2geo -n \
-  < es/provinces.json \
-  provinces=es/_provinces.json
-
-geo2topo -n \
-  provinces=<( \
-      cat es/_provinces.json \
-        | ndjson-map "$NDJSONMAP_ARGS") \
-  autonomous_regions=<( \
-      cat es/_autonomous_regions.json \
-        | ndjson-map "$NDJSONMAP_ARGS") \
-  border=<( \
-      cat es/_border.json \
-        | ndjson-map "$NDJSONMAP_ARGS") \
-  | topoquantize $QUANTIZATION \
-  > es/provinces.json
-
-rm es/_provinces.json es/_autonomous_regions.json es/_border.json
-
-topo2geo -n \
-  < es/municipalities.json \
-  municipalities=es/_municipalities.json \
-  provinces=es/_provinces.json \
-  autonomous_regions=es/_autonomous_regions.json \
-  border=es/_border.json
-
-geo2topo -n \
-  municipalities=<( \
-      cat es/_municipalities.json \
-        | ndjson-map "$NDJSONMAP_ARGS") \
-  provinces=<( \
-      cat es/_provinces.json \
-        | ndjson-map "$NDJSONMAP_ARGS") \
-  autonomous_regions=<( \
-      cat es/_autonomous_regions.json \
-        | ndjson-map "$NDJSONMAP_ARGS") \
-  border=<( \
-      cat es/_border.json \
-        | ndjson-map "$NDJSONMAP_ARGS") \
-  | topoquantize $QUANTIZATION \
-  > es/municipalities.json
-
-rm es/_municipalities.json es/_provinces.json es/_autonomous_regions.json es/_border.json

--- a/properties.js
+++ b/properties.js
@@ -1,0 +1,82 @@
+const shapefile = require("shapefile");
+
+// https://github.com/topojson/us-atlas/blob/master/properties.js
+Promise.all([
+  parseInput(),
+  shapefile.read(
+    "build/recintos_autonomicas_inspire_canarias_wgs84.shp",
+    "build/recintos_autonomicas_inspire_canarias_wgs84.dbf",
+    { encoding: 'utf8' }
+  ),
+  shapefile.read(
+    "build/recintos_autonomicas_inspire_peninbal_etrs89.shp", 
+    "build/recintos_autonomicas_inspire_peninbal_etrs89.dbf", 
+    { encoding: 'utf8' }
+  ),
+  shapefile.read(
+    "build/recintos_provinciales_inspire_canarias_wgs84.shp", 
+    "build/recintos_provinciales_inspire_canarias_wgs84.dbf", 
+    { encoding: 'utf8' }
+  ),
+  shapefile.read(
+    "build/recintos_provinciales_inspire_peninbal_etrs89.shp",
+    "build/recintos_provinciales_inspire_peninbal_etrs89.dbf", 
+    { encoding: 'utf8' }
+  ),
+]).then(output);
+
+function parseInput() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    process.stdin
+        .on("data", chunk => chunks.push(chunk))
+        .on("end", () => {
+          try { resolve(JSON.parse(chunks.join(""))); }
+          catch (error) { reject(error); }
+        })
+        .setEncoding("utf8");
+  });
+}
+
+function output([
+  topology,
+  autonomousRegionsCanaries,
+  autonomousRegionsPeninsula,
+  provincesCanaries,
+  provincesPeninsula,
+]) {
+  const autonomousRegions = autonomousRegionsCanaries.features.concat(autonomousRegionsPeninsula.features);
+  const provinces = provincesCanaries.features.concat(provincesPeninsula.features);
+
+  const autonomousRegionsMap = new Map(autonomousRegions.map(d => [d.properties.NATCODE.slice(2, 4), d.properties]));
+  const provincesMap = new Map(provinces.map(d => [d.properties.NATCODE.slice(4, 6), d.properties]));
+
+  for (const autonomousRegion of topology.objects.autonomous_regions.geometries) {
+    autonomousRegion.properties = {
+      name: autonomousRegionsMap.get(autonomousRegion.id).NAMEUNIT
+    };
+  }
+
+  if (topology.objects.provinces) {
+    for (const province of topology.objects.provinces.geometries) {
+      province.properties = {
+        name: provincesMap.get(province.id).NAMEUNIT
+      };
+    }
+  }
+
+  if (topology.objects.municipalities) {
+    for (const municipality of topology.objects.municipalities.geometries) {
+      municipality.properties = {
+        name: municipality.properties.NAMEUNIT
+      };
+    }
+  }
+
+  for (const border of topology.objects.border.geometries) {
+    border.properties = {};
+  }
+
+  process.stdout.write(JSON.stringify(topology));
+  process.stdout.write("\n");
+}


### PR DESCRIPTION
Adds a `properties.js` file where we fetch names from the shapefiles and pass them onto every admin level.

Remove `add_names` as an option as it is too cumbersome to pass a conditional into a pipe.

Fixes https://github.com/martgnz/es-atlas/issues/13.