### PR TITLE
Theres an extra semicolon on Readme.md example that makes the d3 client example throw an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const projection = d3.geoConicConformalSpain();
 const path = d3.geoPath(projection);
 
 d3.json("https://unpkg.com/es-atlas/es/municipalities.json")
-  .catch(err => console.warn(err));
+  .catch(err => console.warn(err))
   .then(es => {
     svg
       .append('path')


### PR DESCRIPTION
I was playing with your example in codepen and found that tiny tipo:

```
  .catch(err => console.warn(err)); // Semicolon here, I think is just a typo
  .then(es => {
```
