### PR TITLE
Consistent properties in autonomous regions file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-atlas",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Pre-built TopoJSON from the Spanish National Geographic Institute",
   "scripts": {
     "prepare": "bash prepublish",

--- a/prepublish
+++ b/prepublish
@@ -51,6 +51,7 @@ geo2topo -n autonomous_regions=<( \
   | toposimplify -f -p $SIMPLIFICATION \
   | topoquantize $QUANTIZATION \
   | topomerge border=autonomous_regions \
+  | node ./properties.js \
   > es/autonomous_regions.json
 
 geo2topo -n provinces=<( \


### PR DESCRIPTION
I think this was an oversight when we wrote the properties script. This ensures that we have same properties (name, id) in all the files.

Right now it's including the original metadata and we don't need all of it.

## before
<img width="329" alt="imagen" src="https://github.com/martgnz/es-atlas/assets/1236790/ef014b97-907c-42a6-9981-ea272fb6cc19">

## after
<img width="246" alt="imagen" src="https://github.com/martgnz/es-atlas/assets/1236790/a2ed98f0-b3cf-4195-af04-0a66130a4d25">
